### PR TITLE
fix plot recipes, reexport LearnBase

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.4
 
 RecipesBase
+Reexport

--- a/src/Losses.jl
+++ b/src/Losses.jl
@@ -2,7 +2,8 @@ __precompile__()
 
 module Losses
 
-importall LearnBase
+using Reexport
+@reexport using LearnBase
 using RecipesBase
 
 export

--- a/src/supervised/io.jl
+++ b/src/supervised/io.jl
@@ -10,26 +10,26 @@ Base.print(io::IO, loss::SmoothedL1HingeLoss, args...) = print(io, typeof(loss).
 # -------------------------------------------------------------
 # Plot Recipes
 
-_loss_xlabel(loss::Union{MarginLoss, ZeroOneLoss}) = "y ⋅ h(x)"
-_loss_xlabel(loss::DistanceLoss) = "h(x) - y"
+_loss_xguide(loss::Union{MarginLoss, ZeroOneLoss}) = "y ⋅ h(x)"
+_loss_xguide(loss::DistanceLoss) = "h(x) - y"
 
 @recipe function plot(loss::SupervisedLoss, xmin = -2, xmax = 2)
-    :xlabel --> _loss_xlabel(loss)
-    :ylabel --> "L(y, h(x))"
+    :xguide --> _loss_xguide(loss)
+    :yguide --> "L(y, h(x))"
     :label  --> string(loss)
     value_fun(loss), xmin, xmax
 end
 
 @recipe function plot{T<:SupervisedLoss}(losses::AbstractVector{T}, xmin = -2, xmax = 2)
-    :ylabel --> "L(y, h(x))"
+    :yguide --> "L(y, h(x))"
     :label  --> map(string, losses)'
     if issubplot
         :n      --> length(losses)
         :legend --> false
         :title  --> d[:label]
-        :xlabel --> map(_loss_xlabel, losses)'
+        :xguide --> map(_loss_xguide, losses)'
     else
-        :xlabel --> _loss_xlabel(first(losses))
+        :xguide --> _loss_xguide(first(losses))
     end
     map(value_fun, losses), xmin, xmax
 end


### PR DESCRIPTION
Plots now uses x/y `guide` rather than x/y `label`.

Also, it seems we are converging on re-exporting `LearnBase` via the Reexport package/macro. So I added that.