### PR TITLE
Get this working on v0.5

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.4
-
+Compat
 RecipesBase
 Reexport

--- a/src/Losses.jl
+++ b/src/Losses.jl
@@ -9,6 +9,7 @@ import Base.*
 # to be replaced with Reexport as soon as it's importall issues are fixed
 importall LearnBase
 eval(Expr(:toplevel, Expr(:export, setdiff(names(LearnBase), [:LearnBase])...)))
+using Compat
 
 export
 

--- a/src/supervised/scaledloss.jl
+++ b/src/supervised/scaledloss.jl
@@ -1,10 +1,10 @@
 for KIND in (:MarginLoss, :DistanceLoss)
     @eval begin
-        immutable $(symbol("Scaled", KIND)){L<:$KIND,T<:Number} <: $KIND
+        immutable $(@compat Symbol("Scaled", KIND)){L<:$KIND,T<:Number} <: $KIND
             loss::L
             factor::T
         end
-        (*)(factor::Number, loss::$KIND) = $(symbol("Scaled", KIND))(loss, factor)
+        (*)(factor::Number, loss::$KIND) = $(Symbol("Scaled", KIND))(loss, factor)
     end
 end
 

--- a/src/supervised/scaledloss.jl
+++ b/src/supervised/scaledloss.jl
@@ -10,7 +10,11 @@ end
 
 typealias ScaledLoss Union{ScaledMarginLoss, ScaledDistanceLoss}
 
-Base.convert(::Type{ScaledLoss}, l::Loss, factor::Number) = factor * l
+if VERSION >= v"0.5-"
+    ScaledLoss(l::Loss, factor::Number) = factor * l
+else
+    Base.convert(::Type{ScaledLoss}, l::Loss, factor::Number) = factor * l
+end
 
 value_deriv(l::ScaledLoss, num::Number) = (l.factor * value(l.loss, num), l.factor * deriv(l.loss, num))
 

--- a/test/tst_loss.jl
+++ b/test/tst_loss.jl
@@ -149,7 +149,7 @@ end
 function test_deriv2(l::MarginLoss, t_vec)
     @testset "$(l): " begin
         for y in [-1., 1], t in t_vec
-            if istwicedifferentiable(l, y*t)
+            if istwicedifferentiable(l, y*t) && isdifferentiable(l, y*t)
                 d2_dual = epsilon(deriv(l, dual(y, 0), dual(t, 1)))
                 d2_comp = deriv2(l, y, t)
                 @test abs(d2_dual - d2_comp) < 1e-10
@@ -168,7 +168,7 @@ end
 function test_deriv2(l::DistanceLoss, t_vec)
     @testset "$(l): " begin
         for y in -20:.2:20, t in t_vec
-            if istwicedifferentiable(l, t-y)
+            if istwicedifferentiable(l, t-y) && isdifferentiable(l, t-y)
                 d2_dual = epsilon(deriv(l, dual(t-y, 1)))
                 d2_comp = deriv2(l, y, t)
                 @test abs(d2_dual - d2_comp) < 1e-10


### PR DESCRIPTION
Summary of changes:

* `symbol(...)` is deprecated. Updated to `Symbol(...)` in ScaledLoss constructor.
* Create a constructor for `ScaledLoss` -- this is now allowed for `typealias`es. The `convert` method before was causing errors, so I think this is the correct way to do it now.
* Everything should still work on v0.4 -- I introduced a dependency on Compat to achieve this

The following a bit more tricky and needs discussion:

* I changed the test for `test_deriv2` to not test at points where the loss is not once differentiable. This was because `L1DistLoss` was erroring at `(y-t)=0`. Dual numbers was thinking that the second derivative should be 1 at this point... Is this just a problem with Dual Numbers not handling the discontinuity correctly? I think skipping non-differentiable points is reasonable anyways though.

This is ready for your review @Evizero and merge if you approve.