### PR TITLE
Broadcast value and deriv on arrays

### DIFF
--- a/src/Losses.jl
+++ b/src/Losses.jl
@@ -5,6 +5,7 @@ module Losses
 using RecipesBase
 
 import Base.*
+using Base.Cartesian
 
 # to be replaced with Reexport as soon as it's importall issues are fixed
 importall LearnBase

--- a/src/supervised/supervised.jl
+++ b/src/supervised/supervised.jl
@@ -61,11 +61,11 @@ end
         target::AbstractArray{Q,M},
         output::AbstractArray{T,N}
     )
+    M > N && throw(ArgumentError("target has more dimensions than output; broadcasting not supported in this direction."))
     quote
       @_dimcheck size(buffer) == size(output)
-      @nexprs $N (n)->(s_n = size(output,n))
-      @nexprs $M (n)->@_dimcheck(size(target,n) == s_n)
-      @simd for I in CartesianRange(@ntuple($N,n->(1:s_n)))
+      @nexprs $M (n)->@_dimcheck(size(target,n) == size(output,n))
+      @simd for I in CartesianRange(size(output))
           @nexprs $N n->(i_n = I[n])
           @inbounds @nref($N,buffer,i) = value(loss, @nref($M,target,i), @nref($N,output,i))
       end
@@ -79,11 +79,11 @@ end
         target::AbstractArray{Q,M},
         output::AbstractArray{T,N}
     )
+    M > N && throw(ArgumentError("target has more dimensions than output; broadcasting not supported in this direction."))
     quote
       @_dimcheck size(buffer) == size(output)
-      @nexprs $N (n)->(s_n = size(output,n))
-      @nexprs $M (n)->@_dimcheck(size(target,n) == s_n)
-      @simd for I in CartesianRange(@ntuple($N,n->(1:s_n)))
+      @nexprs $M (n)->@_dimcheck(size(target,n) == size(output,n))
+      @simd for I in CartesianRange(size(output))
           @nexprs $N n->(i_n = I[n])
           @inbounds @nref($N,buffer,i) = deriv(loss, @nref($M,target,i), @nref($N,output,i))
       end
@@ -109,12 +109,11 @@ end
         target::AbstractArray{Q,M},
         output::AbstractArray{T,N}
     )
+    M > N && throw(ArgumentError("target has more dimensions than output; broadcasting not supported in this direction."))
     quote
-      @_dimcheck size(buffer) == size(output)
-      @nexprs $N (n)->(s_n = size(output,n))
-      @nexprs $M (n)->@_dimcheck(size(target,n) == s_n)
+      @nexprs $M (n)->@_dimcheck(size(target,n) == size(output,n))
       val = zero(T) # TODO: this might be not be type-stable?
-      @simd for I in CartesianRange(@ntuple($N,n->(1:s_n)))
+      @simd for I in CartesianRange(size(output))
           @nexprs $N n->(i_n = I[n])
           @inbounds val += value(loss, @nref($M,target,i), @nref($N,output,i))
       end
@@ -127,12 +126,11 @@ end
         target::AbstractArray{Q,M},
         output::AbstractArray{T,N}
     )
+    M > N && throw(ArgumentError("target has more dimensions than output; broadcasting not supported in this direction."))
     quote
-      @_dimcheck size(buffer) == size(output)
-      @nexprs $N (n)->(s_n = size(output,n))
-      @nexprs $M (n)->@_dimcheck(size(target,n) == s_n)
+      @nexprs $M (n)->@_dimcheck(size(target,n) == size(output,n))
       val = zero(T) # TODO: this might be not be type-stable?
-      @simd for I in CartesianRange(@ntuple($N,n->(1:s_n)))
+      @simd for I in CartesianRange(size(output))
           @nexprs $N n->(i_n = I[n])
           @inbounds val += deriv(loss, @nref($M,target,i), @nref($N,output,i))
       end
@@ -147,15 +145,16 @@ end
         target::AbstractArray{Q,M},
         output::AbstractArray{T,N}
     )
+    M > N && throw(ArgumentError("target has more dimensions than output; broadcasting not supported in this direction."))
     quote
-      @_dimcheck size(buffer) == size(output)
-      @nexprs $N (n)->(s_n = size(output,n))
-      @nexprs $M (n)->@_dimcheck(size(target,n) == s_n)
+      @nexprs $M (n)->@_dimcheck(size(target,n) == size(output,n))
       val = zero(T) # TODO: this might be not be type-stable?
       tmp = zero(T) # TODO: this might be not be type-stable?
-      @simd for I in CartesianRange(@ntuple($N,n->(1:s_n)))
+      len = length(output)
+      @simd for I in CartesianRange(size(output))
+          @nexprs $N n->(i_n = I[n])
           @inbounds tmp = value(loss, @nref($M,target,i), @nref($N,output,i))
-          tmp /= n # is this to prevent overflow?
+          tmp /= len # is this to prevent overflow?
           val += tmp
       end
       val
@@ -167,15 +166,16 @@ end
         target::AbstractArray{Q,M},
         output::AbstractArray{T,N}
     )
+    M > N && throw(ArgumentError("target has more dimensions than output; broadcasting not supported in this direction."))
     quote
-      @_dimcheck size(buffer) == size(output)
-      @nexprs $N (n)->(s_n = size(output,n))
-      @nexprs $M (n)->@_dimcheck(size(target,n) == s_n)
+      @nexprs $M (n)->@_dimcheck(size(target,n) == size(output,n))
       val = zero(T) # TODO: this might be not be type-stable?
       tmp = zero(T) # TODO: this might be not be type-stable?
-      @simd for I in CartesianRange(@ntuple($N,n->(1:s_n)))
+      len = length(output)
+      @simd for I in CartesianRange(size(output))
+          @nexprs $N n->(i_n = I[n])
           @inbounds tmp = deriv(loss, @nref($M,target,i), @nref($N,output,i))
-          tmp /= n # is this to prevent overflow?
+          tmp /= len # is this to prevent overflow?
           val += tmp
       end
       val

--- a/src/supervised/supervised.jl
+++ b/src/supervised/supervised.jl
@@ -46,11 +46,6 @@ end
     deriv!(buffer, loss, target, output)
 end
 
-# @inline function grad(loss::SupervisedLoss, target::AbstractMatrix, output::AbstractVecOrMat)
-#     buffer = similar(output)
-#     grad!(buffer, loss, target, output)
-# end
-
 # --------------------------------------------------------------
 # value!, deriv!
 # `output` can have more dimensions than `target`, in which case do broadcasting
@@ -90,18 +85,6 @@ end
       buffer
     end
 end
-
-# function grad!(buffer::AbstractMatrix, loss::SupervisedLoss, target::AbstractMatrix, output::AbstractMatrix)
-#     n = size(output, 2)
-#     k = size(output, 1)
-#     @_dimcheck size(target) == size(output) && size(buffer) == (k, n)
-#     for i = 1:n
-#         @simd for j = 1:k
-#             @inbounds buffer[j, i] = deriv(loss, target[j, i], output[j, i])
-#         end
-#     end
-#     buffer
-# end
 
 # --------------------------------------------------------------
 @generated function sumvalue{T,N,Q,M}(
@@ -154,7 +137,7 @@ end
       @simd for I in CartesianRange(size(output))
           @nexprs $N n->(i_n = I[n])
           @inbounds tmp = value(loss, @nref($M,target,i), @nref($N,output,i))
-          tmp /= len # is this to prevent overflow?
+          tmp /= len
           val += tmp
       end
       val
@@ -175,7 +158,7 @@ end
       @simd for I in CartesianRange(size(output))
           @nexprs $N n->(i_n = I[n])
           @inbounds tmp = deriv(loss, @nref($M,target,i), @nref($N,output,i))
-          tmp /= len # is this to prevent overflow?
+          tmp /= len
           val += tmp
       end
       val

--- a/src/supervised/supervised.jl
+++ b/src/supervised/supervised.jl
@@ -36,141 +36,150 @@ islipschitzcont_deriv(::SupervisedLoss) = false
 
 # --------------------------------------------------------------
 
-@inline function value(loss::SupervisedLoss, target::AbstractVecOrMat, output::AbstractVecOrMat)
+@inline function value(loss::SupervisedLoss, target::AbstractArray, output::AbstractArray)
     buffer = similar(output)
     value!(buffer, loss, target, output)
 end
 
-@inline function deriv(loss::SupervisedLoss, target::AbstractVector, output::AbstractVecOrMat)
+@inline function deriv(loss::SupervisedLoss, target::AbstractArray, output::AbstractArray)
     buffer = similar(output)
     deriv!(buffer, loss, target, output)
 end
 
-@inline function grad(loss::SupervisedLoss, target::AbstractMatrix, output::AbstractVecOrMat)
-    buffer = similar(output)
-    grad!(buffer, loss, target, output)
+# @inline function grad(loss::SupervisedLoss, target::AbstractMatrix, output::AbstractVecOrMat)
+#     buffer = similar(output)
+#     grad!(buffer, loss, target, output)
+# end
+
+# --------------------------------------------------------------
+# value!, deriv!
+# `output` can have more dimensions than `target`, in which case do broadcasting
+
+@generated function value!{T,N,Q,M}(
+        buffer::AbstractArray,
+        loss::SupervisedLoss,
+        target::AbstractArray{Q,M},
+        output::AbstractArray{T,N}
+    )
+    quote
+      @_dimcheck size(buffer) == size(output)
+      @nexprs $N (n)->(s_n = size(output,n))
+      @nexprs $M (n)->@_dimcheck(size(target,n) == s_n)
+      @simd for I in CartesianRange(@ntuple($N,n->(1:s_n)))
+          @nexprs $N n->(i_n = I[n])
+          @inbounds @nref($N,buffer,i) = value(loss, @nref($M,target,i), @nref($N,output,i))
+      end
+      buffer
+    end
+end
+
+@generated function deriv!{T,N,Q,M}(
+        buffer::AbstractArray,
+        loss::SupervisedLoss,
+        target::AbstractArray{Q,M},
+        output::AbstractArray{T,N}
+    )
+    quote
+      @_dimcheck size(buffer) == size(output)
+      @nexprs $N (n)->(s_n = size(output,n))
+      @nexprs $M (n)->@_dimcheck(size(target,n) == s_n)
+      @simd for I in CartesianRange(@ntuple($N,n->(1:s_n)))
+          @nexprs $N n->(i_n = I[n])
+          @inbounds @nref($N,buffer,i) = deriv(loss, @nref($M,target,i), @nref($N,output,i))
+      end
+      buffer
+    end
+end
+
+# function grad!(buffer::AbstractMatrix, loss::SupervisedLoss, target::AbstractMatrix, output::AbstractMatrix)
+#     n = size(output, 2)
+#     k = size(output, 1)
+#     @_dimcheck size(target) == size(output) && size(buffer) == (k, n)
+#     for i = 1:n
+#         @simd for j = 1:k
+#             @inbounds buffer[j, i] = deriv(loss, target[j, i], output[j, i])
+#         end
+#     end
+#     buffer
+# end
+
+# --------------------------------------------------------------
+@generated function sumvalue{T,N,Q,M}(
+        loss::SupervisedLoss,
+        target::AbstractArray{Q,M},
+        output::AbstractArray{T,N}
+    )
+    quote
+      @_dimcheck size(buffer) == size(output)
+      @nexprs $N (n)->(s_n = size(output,n))
+      @nexprs $M (n)->@_dimcheck(size(target,n) == s_n)
+      val = zero(T) # TODO: this might be not be type-stable?
+      @simd for I in CartesianRange(@ntuple($N,n->(1:s_n)))
+          @nexprs $N n->(i_n = I[n])
+          @inbounds val += value(loss, @nref($M,target,i), @nref($N,output,i))
+      end
+      val
+    end
+end
+
+@generated function sumderiv{T,N,Q,M}(
+        loss::SupervisedLoss,
+        target::AbstractArray{Q,M},
+        output::AbstractArray{T,N}
+    )
+    quote
+      @_dimcheck size(buffer) == size(output)
+      @nexprs $N (n)->(s_n = size(output,n))
+      @nexprs $M (n)->@_dimcheck(size(target,n) == s_n)
+      val = zero(T) # TODO: this might be not be type-stable?
+      @simd for I in CartesianRange(@ntuple($N,n->(1:s_n)))
+          @nexprs $N n->(i_n = I[n])
+          @inbounds val += deriv(loss, @nref($M,target,i), @nref($N,output,i))
+      end
+      val
+    end
 end
 
 # --------------------------------------------------------------
 
-function value!(buffer::AbstractVector, loss::SupervisedLoss, target::AbstractVector, output::AbstractVector)
-    n = length(output)
-    @_dimcheck length(target) == n && size(buffer) == size(output)
-    @simd for i = 1:n
-        @inbounds buffer[i] = value(loss, target[i], output[i])
+@generated function meanvalue{T,N,Q,M}(
+        loss::SupervisedLoss,
+        target::AbstractArray{Q,M},
+        output::AbstractArray{T,N}
+    )
+    quote
+      @_dimcheck size(buffer) == size(output)
+      @nexprs $N (n)->(s_n = size(output,n))
+      @nexprs $M (n)->@_dimcheck(size(target,n) == s_n)
+      val = zero(T) # TODO: this might be not be type-stable?
+      tmp = zero(T) # TODO: this might be not be type-stable?
+      @simd for I in CartesianRange(@ntuple($N,n->(1:s_n)))
+          @inbounds tmp = value(loss, @nref($M,target,i), @nref($N,output,i))
+          tmp /= n # is this to prevent overflow?
+          val += tmp
+      end
+      val
     end
-    buffer
 end
 
-function deriv!(buffer::AbstractVector, loss::SupervisedLoss, target::AbstractVector, output::AbstractVector)
-    n = length(output)
-    @_dimcheck length(target) == n && size(buffer) == size(output)
-    @simd for i = 1:n
-        @inbounds buffer[i] = deriv(loss, target[i], output[i])
+@generated function meanderiv{T,N,Q,M}(
+        loss::SupervisedLoss,
+        target::AbstractArray{Q,M},
+        output::AbstractArray{T,N}
+    )
+    quote
+      @_dimcheck size(buffer) == size(output)
+      @nexprs $N (n)->(s_n = size(output,n))
+      @nexprs $M (n)->@_dimcheck(size(target,n) == s_n)
+      val = zero(T) # TODO: this might be not be type-stable?
+      tmp = zero(T) # TODO: this might be not be type-stable?
+      @simd for I in CartesianRange(@ntuple($N,n->(1:s_n)))
+          @inbounds tmp = deriv(loss, @nref($M,target,i), @nref($N,output,i))
+          tmp /= n # is this to prevent overflow?
+          val += tmp
+      end
+      val
     end
-    buffer
-end
-
-# --------------------------------------------------------------
-
-function value!(buffer::AbstractMatrix, loss::SupervisedLoss, target::AbstractVector, output::AbstractMatrix)
-    n = size(output, 2)
-    k = size(output, 1)
-    @_dimcheck length(target) == n && size(buffer) == (k, n)
-    for i = 1:n
-        @simd for j = 1:k
-            @inbounds buffer[j, i] = value(loss, target[i], output[j, i])
-        end
-    end
-    buffer
-end
-
-function deriv!(buffer::AbstractMatrix, loss::SupervisedLoss, target::AbstractVector, output::AbstractMatrix)
-    n = size(output, 2)
-    k = size(output, 1)
-    @_dimcheck length(target) == n && size(buffer) == (k, n)
-    for i = 1:n
-        @simd for j = 1:k
-            @inbounds buffer[j, i] = deriv(loss, target[i], output[j, i])
-        end
-    end
-    buffer
-end
-
-# --------------------------------------------------------------
-
-function value!(buffer::AbstractMatrix, loss::SupervisedLoss, target::AbstractMatrix, output::AbstractMatrix)
-    n = size(output, 2)
-    k = size(output, 1)
-    @_dimcheck size(target) == size(output) && size(buffer) == (k, n)
-    for i = 1:n
-        @simd for j = 1:k
-            @inbounds buffer[j, i] = value(loss, target[j, i], output[j, i])
-        end
-    end
-    buffer
-end
-
-function grad!(buffer::AbstractMatrix, loss::SupervisedLoss, target::AbstractMatrix, output::AbstractMatrix)
-    n = size(output, 2)
-    k = size(output, 1)
-    @_dimcheck size(target) == size(output) && size(buffer) == (k, n)
-    for i = 1:n
-        @simd for j = 1:k
-            @inbounds buffer[j, i] = deriv(loss, target[j, i], output[j, i])
-        end
-    end
-    buffer
-end
-
-# --------------------------------------------------------------
-
-function sumvalue{T<:Number}(loss::SupervisedLoss, target::AbstractVector, output::AbstractArray{T})
-    n = length(output)
-    @_dimcheck length(target) == n
-    val = zero(T)
-    @simd for i = 1:n
-        @inbounds val += value(loss, target[i], output[i])
-    end
-    val
-end
-
-function sumderiv{T<:Number}(loss::SupervisedLoss, target::AbstractVector, output::AbstractArray{T})
-    n = length(output)
-    @_dimcheck length(target) == n
-    val = zero(T)
-    @simd for i = 1:n
-        @inbounds val += deriv(loss, target[i], output[i])
-    end
-    val
-end
-
-# --------------------------------------------------------------
-
-function meanvalue{T<:Number}(loss::SupervisedLoss, target::AbstractVector, output::AbstractArray{T})
-    n = length(output)
-    @_dimcheck length(target) == n
-    val = zero(T)
-    tmp = zero(T)
-    @simd for i = 1:n
-        @inbounds tmp = value(loss, target[i], output[i])::T
-        tmp /= n
-        val += tmp
-    end
-    val
-end
-
-function meanderiv{T<:Number}(loss::SupervisedLoss, target::AbstractVector, output::AbstractArray{T})
-    n = length(output)
-    @_dimcheck length(target) == n
-    val = zero(T)
-    tmp = zero(T)
-    @simd for i = 1:n
-        @inbounds tmp = deriv(loss, target[i], output[i])::T
-        tmp /= n
-        val += tmp
-    end
-    val
 end
 
 ismarginbased(::SupervisedLoss) = false

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,8 @@ else
 end
 
 tests = [
-    "tst_loss.jl"
+    "tst_loss.jl",
+    "tst_api.jl"
 ]
 
 perf = [

--- a/test/tst_api.jl
+++ b/test/tst_api.jl
@@ -1,0 +1,22 @@
+
+@testset "Broadcasting higher-order arrays" begin
+    for f in (value,deriv,sumvalue,sumderiv,meanvalue,meanderiv)
+        @testset "$f" begin
+            
+            m,n,k = 100,99,98
+            loss = L2DistLoss()
+            
+            targ1 = randn(m)
+            targ2 = repeat(targ1,outer=(1,n))
+            targ3 = repeat(targ1,outer=(1,n,k))
+            
+            out1 = randn(m,n)
+            out2 = randn(m,n,k)
+
+            @test isapprox(f(loss,targ1,out1), f(loss,targ2,out1))
+            @test isapprox(f(loss,targ1,out2), f(loss,targ2,out2))
+            @test isapprox(f(loss,targ1,out2), f(loss,targ3,out2))
+            @test isapprox(f(loss,targ2,out2), f(loss,targ3,out2))
+        end
+    end
+end

--- a/test/tst_api.jl
+++ b/test/tst_api.jl
@@ -1,4 +1,3 @@
-
 @testset "Broadcasting higher-order arrays" begin
     for f in (value,deriv,sumvalue,sumderiv,meanvalue,meanderiv)
         @testset "$f" begin
@@ -17,6 +16,9 @@
             @test isapprox(f(loss,targ1,out2), f(loss,targ2,out2))
             @test isapprox(f(loss,targ1,out2), f(loss,targ3,out2))
             @test isapprox(f(loss,targ2,out2), f(loss,targ3,out2))
+
+            # can't broadcast in this direction (yet)
+            @test_throws Exception f(loss,targ3,out1)
         end
     end
 end


### PR DESCRIPTION
This isn't quite ready to merge, but this would be my solution to: https://github.com/JuliaML/Losses.jl/issues/28

The basic idea is shown in the simple example below -- `target` can have fewer dimensions than `output` for broadcasting. I think it wouldn't be hard to also allow broadcasting in the opposite direction if this is of interest.

<img width="655" alt="screen shot 2016-08-17 at 12 26 07 pm" src="https://cloud.githubusercontent.com/assets/636625/17750245/508d2544-6476-11e6-8569-89a641c1a212.png">

This should be just as fast as whatever we have now -- it is similar to how `Base` implements `broadcast!` which indicates to me that this is a good approach. The code should work for arbitrary dimensions of `target` and `output`.

Would appreciate feedback on this -- if we like this approach I'll add some better tests. (The tests we have currently pass on v0.5)